### PR TITLE
fix issue with ip4 addresses below 128.0.0.0

### DIFF
--- a/luxtronik/datatypes.py
+++ b/luxtronik/datatypes.py
@@ -82,11 +82,15 @@ class IPAddress(Base):
     measurement_type = "ipaddress"
 
     def _to(self, v):
-        return str(ipaddress.IPv4Address(v + 2 ** 32))
+        if v<0:
+            return str(ipaddress.IPv4Address(v + 2 ** 32))
+        return str(ipaddress.IPv4Address(v))
 
     def _from(self, v):
-        return int(ipaddress.IPv4Address(v)) - 2 ** 32
-
+        result = int(ipaddress.IPv4Address(v))
+        if result > 2 ** 32:
+            return result - 2 ** 32
+        return result
 
 class Timestamp(Base):
 


### PR DESCRIPTION
If IP addresses are below 128.0.0.0 the corresponding integer value is not below 0, so adding 2 **32  to the value results in illegal values and the reading of values crashes