### PR TITLE
Use unique_id instead of entity_id

### DIFF
--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -91,13 +91,9 @@ class LuxtronikSensor(SensorEntity):
         self._name = friendly_name
         self._icon = icon
         self._state_class = state_class
-
-    @property
-    def entity_id(self):
-        """Return the entity_id of the sensor."""
-        if not self._name:
-            return ENTITY_ID_FORMAT.format(slugify(self._sensor.name))
-        return ENTITY_ID_FORMAT.format(slugify(self._name))
+        self._attr_unique_id = ENTITY_ID_FORMAT.format(
+            slugify(self._sensor.name if not self._name else self._name)
+        )
 
     @property
     def name(self):


### PR DESCRIPTION
Generate the unique_id attribute to avoid errors like

> This entity ('luxtronik.*') does not have a unique ID, therefore its settings cannot be managed from the UI.

when trying to modify existing entities in the UI.