### PR TITLE
Derive the unique_id from the sensor name

### DIFF
--- a/custom_components/luxtronik/binary_sensor.py
+++ b/custom_components/luxtronik/binary_sensor.py
@@ -87,7 +87,7 @@ class LuxtronikBinarySensor(BinarySensorEntity):
         self._icon = icon
         self._invert = invert_state
         self._attr_unique_id = ENTITY_ID_FORMAT.format(
-            slugify(self._sensor.name if not self._name else self._name)
+            slugify(self._sensor.name)
         )
 
     @property

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -92,7 +92,7 @@ class LuxtronikSensor(SensorEntity):
         self._icon = icon
         self._state_class = state_class
         self._attr_unique_id = ENTITY_ID_FORMAT.format(
-            slugify(self._sensor.name if not self._name else self._name)
+            slugify(self._sensor.name)
         )
 
     @property


### PR DESCRIPTION
This leads to more "stable" unique_ids, not losing the history data after changing the friendly_name property in
the configuration.