### PR TITLE
Use `datatype_class` and `datatype_unit` instead of `measurement_type`

### DIFF
--- a/custom_components/luxtronik/const.py
+++ b/custom_components/luxtronik/const.py
@@ -23,37 +23,47 @@ CONF_PARAMETERS = "parameters"
 CONF_CALCULATIONS = "calculations"
 CONF_VISIBILITIES = "visibilities"
 
-CONF_CELSIUS = "celsius"
-CONF_SECONDS = "seconds"
+CONF_TEMP = "temperature"
+CONF_FREQUENCY = "frequency"
+CONF_TIMESPAN = "timespan"
+CONF_PRESSURE = "pressure"
 CONF_TIMESTAMP = "timestamp"
-CONF_KELVIN = "kelvin"
-CONF_BAR = "bar"
-CONF_PERCENT = "percent"
 CONF_ENERGY = "energy"
+CONF_POWER = "power"
 CONF_VOLTAGE = "voltage"
-CONF_HOURS = "hours"
+CONF_SPEED = "speed"
 CONF_FLOW = "flow"
+
+CONF_CELSIUS = "°C"
+CONF_HOURS = "h"
+CONF_MIN = "min"
+CONF_SECONDS = "s"
+CONF_KELVIN = "K"
+CONF_BAR = "bar"
+CONF_PERCENT = "%"
+CONF_KWH = "kWh"
+CONF_VOLT = "V"
+CONF_LPH = "l/h"
 CONF_WATT = "W"
-CONF_FREQUENCY = "Hz"
+CONF_HZ = "Hz"
+CONF_RPM = "rpm"
 
 CONF_LOCK_TIMEOUT = "lock_timeout"
 CONF_UPDATE_IMMEDIATELY_AFTER_WRITE = "update_immediately_after_write"
 
 
 ICONS = {
-    "celsius": "mdi:thermometer",
-    "seconds": "mdi:timer-sand",
-    "pulses": "mdi:pulse",
-    "ipaddress": "mdi:ip-network-outline",
+    "temperature": "mdi:thermometer",
+    "timespan": "mdi:timer-sand",
+    "ipv4_address": "mdi:ip-network-outline",
     "timestamp": "mdi:calendar-range",
     "errorcode": "mdi:alert-circle-outline",
-    "kelvin": "mdi:thermometer",
-    "bar": "mdi:arrow-collapse-all",
+    "pressure": "mdi:arrow-collapse-all",
     "percent": "mdi:percent",
-    "rpm": "mdi:rotate-right",
-    "energy": "mdi:flash-circle",
+    "speed": "mdi:rotate-right",
+    "power": "mdi:flash",
+    "energy": "mdi:lightning-bolt-circle",
     "voltage": "mdi:flash-outline",
-    "hours": "mdi:clock-outline",
     "flow": "mdi:chart-bell-curve",
     "level": "mdi:format-list-numbered",
     "count": "mdi:counter",
@@ -62,15 +72,16 @@ ICONS = {
 }
 
 DEVICE_CLASSES = {
-    CONF_CELSIUS: SensorDeviceClass.TEMPERATURE,
-    CONF_KELVIN: SensorDeviceClass.TEMPERATURE,
-    CONF_BAR: SensorDeviceClass.PRESSURE,
-    CONF_SECONDS: SensorDeviceClass.DURATION,
-    CONF_HOURS: SensorDeviceClass.DURATION,
+    CONF_TEMP: SensorDeviceClass.TEMPERATURE,
+    CONF_PRESSURE: SensorDeviceClass.PRESSURE,
+    CONF_TIMESPAN: SensorDeviceClass.DURATION,
     CONF_TIMESTAMP: SensorDeviceClass.TIMESTAMP,
     CONF_ENERGY: SensorDeviceClass.ENERGY,
-    CONF_WATT: SensorDeviceClass.POWER,
+    CONF_POWER: SensorDeviceClass.POWER,
     CONF_FREQUENCY: SensorDeviceClass.FREQUENCY,
+    CONF_VOLTAGE: SensorDeviceClass.VOLTAGE,
+    CONF_SPEED: SensorDeviceClass.SPEED,
+    CONF_FLOW: SensorDeviceClass.VOLUME_FLOW_RATE,
 }
 
 UNITS = {
@@ -79,10 +90,12 @@ UNITS = {
     CONF_KELVIN: UnitOfTemperature.KELVIN,
     CONF_BAR: UnitOfPressure.BAR,
     CONF_PERCENT: PERCENTAGE,
-    CONF_ENERGY: UnitOfEnergy.KILO_WATT_HOUR,
-    CONF_VOLTAGE: UnitOfElectricPotential.VOLT,
+    CONF_KWH: UnitOfEnergy.KILO_WATT_HOUR,
+    CONF_VOLT: UnitOfElectricPotential.VOLT,
     CONF_HOURS: UnitOfTime.HOURS,
-    CONF_FLOW: "l/h",
+    CONF_MIN: UnitOfTime.MINUTES,
+    CONF_LPH: "l/h",
     CONF_WATT: UnitOfPower.WATT,
-    CONF_FREQUENCY: UnitOfFrequency.HERTZ
+    CONF_HZ: UnitOfFrequency.HERTZ,
+    CONF_RPM: "rpm",
 }

--- a/custom_components/luxtronik/manifest.json
+++ b/custom_components/luxtronik/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/luxtronik",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Bouni/luxtronik/issues",
-  "requirements": ["luxtronik==0.3.14"],
+  "requirements": ["luxtronik>0.3.14"],
   "version": "2022.12.01"
 }

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -106,7 +106,7 @@ class LuxtronikSensor(SensorEntity):
     def icon(self):
         """Icon to use in the frontend, if any."""
         if not self._icon:
-            return ICONS.get(self._sensor.measurement_type)
+            return ICONS.get(self._sensor.datatype_class)
         return self._icon
 
     @property
@@ -124,12 +124,12 @@ class LuxtronikSensor(SensorEntity):
     @property
     def device_class(self):
         """Return the class of this sensor."""
-        return DEVICE_CLASSES.get(self._sensor.measurement_type, DEFAULT_DEVICE_CLASS)
+        return DEVICE_CLASSES.get(self._sensor.datatype_class, DEFAULT_DEVICE_CLASS)
 
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return UNITS.get(self._sensor.measurement_type)
+        return UNITS.get(self._sensor.datatype_unit)
 
     def update(self):
         """Get the latest status and use it to update our sensor state."""


### PR DESCRIPTION
`measurement_type` was removed after luxtronik v0.3.14 release. With the use of the new identifiers, the look-up tables for type/unit/icon also had to be changed.

NOTE: I have selected “luxtronik>0.3.14” for the time being until the exact version for the luxtronik interface has been determined.

Tested on HA [2024.10.4](https://www.home-assistant.io/blog/2024/10/02/release-202410/) with https://github.com/Bouni/python-luxtronik/pull/187 and runs in parallel with BenPru/luxtronik.